### PR TITLE
docs: add PROJECT_MANIFEST and align copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@
 This file tells AI coding agents how to be immediately productive in this repository.
 
 1. Big picture
+- Refer to `docs/PROJECT_MANIFEST.md` for the overall architecture, tech stack, and project conventions. Keep the manifest as the canonical source for agent-run rules and priorities.
 - Tech stack: Next.js 14 (app router), React 18, TypeScript, TailwindCSS. Backend logic lives in Next.js server routes under `src/app/(authenticated)/api/*` and feature services in `src/features/*`.
 - Cloud infra: Azure resources are authored in Bicep under `infra/` (main.bicep -> resources.bicep + modules). App deployment expects `output` values from the Bicep modules (App URL, KeyVault names, etc.).
 - Authentication: NextAuth is used; `src/middleware.ts` enforces authentication via `next-auth/jwt.getToken`. Infra controls `USE_MANAGED_IDENTITIES` via `disableLocalAuth` in Bicep.
@@ -163,8 +164,6 @@ The repository owner has mandated the following refactor goals — use these as 
 15. Review and standards
 - Follow industry best practices: fail-fast linting, SARIF uploads, IaC policy enforcement, supply-chain scanning, and least-privilege infra changes. Document any exceptions in `docs/` so reviewers know tradeoffs.
 
-If you want, I can scaffold the GitHub Actions workflow files and the local `scripts/ci-checks.ps1` next.
-
 16. Security scanning (recommended tools & CI integration)
 - Recommended scanners:
   - Checkov: IaC security scanning for Bicep/ARM/Terraform. Use for policy-as-code checks and CIS/OWASP rules.
@@ -187,8 +186,6 @@ If you want, I can scaffold the GitHub Actions workflow files and the local `scr
 - Automation & remediation:
   - Enable Dependabot + Snyk auto-fixes for dependency upgrades.
   - Configure Checkov exceptions via `.checkov.yml` and track approved exceptions in `docs/security-exceptions.md`.
-
-If you want, I can scaffold CI steps for these scanners (GitHub Actions), add minimal config files (`.checkov.yml`, `trivy` scan steps, `semgrep.yml`), and wire SARIF uploads. Tell me which scanners to prioritize first.
 
 If anything in this file is unclear or you'd like me to expand a section (for example: generate a concrete Terraform module plan, or start the APIM + two-app-registration work), tell me which item to prioritize next.
 
@@ -223,8 +220,6 @@ git push azure HEAD:refs/heads/refactor/apim-two-appreg
   - Use `azure-pipelines.yml` in the repo root and keep environment-specific variable groups in the Azure DevOps project.
   - Prefer service connections over embedding credentials. Use Key Vault + variable groups for runtime secrets.
 
-If you want, I can scaffold an `azure-pipelines.yml` skeleton and the Azure DevOps pipeline templates next (I will need your Azure DevOps org/project/repo names or I can use placeholders).
-
 Note: the Azure DevOps repository is assumed to be new and empty. Recommended initial steps for a fresh Azure repo:
 
 - Create the repo in Azure DevOps and set the default branch (e.g., `main` or `develop`).
@@ -235,11 +230,9 @@ Note: the Azure DevOps repository is assumed to be new and empty. Recommended in
   - `src/` (the current application code pushed as a branch)
 - Immediately enable branch policies on the default branch to require PRs, enforce required pipeline checks (`check-code`, `check-infra`), and require code reviews before merge.
 
-If you want, I can scaffold the initial `azure-pipelines.yml` and a minimal first commit structure to push into the empty Azure repo.
-
 **Agent Decision Policy**
-- The repository owner authorizes the AI agent to proceed with implementation and recommendations that align with the user's stated goals without asking for explicit approval for trivial or inferable decisions.
-- The agent should only pause and request confirmation for "critical" decisions, including but not limited to:
+- The repository owner authorizes the AI agent to proceed with implementation and recommendations that align with the user's stated goals without asking for explicit approval for non-critical decisions as defined in `docs/PROJECT_MANIFEST.md`.
+- The agent should pause and request confirmation for "critical" decisions (see manifest for full list), including but not limited to:
   - Changing authentication flows or app registration configuration that affect production security.
   - Modifying Key Vault secret names, rotating secrets, or placing secrets into code or configuration.
   - Making breaking infrastructure changes that could delete or significantly alter deployed resources (for example, deleting resource groups or modifying private-networking that impacts private endpoints).
@@ -310,8 +303,6 @@ git checkout release/1.2.0
 git checkout -b feature/new-search
 git push azure feature/new-search
 ```
-
-If you want, I can update the Azure DevOps pipeline templates to enforce these branch rules and gate merges accordingly.
 
 ## Validation: Complete Coverage of User Requirements
 

--- a/docs/PROJECT_MANIFEST.md
+++ b/docs/PROJECT_MANIFEST.md
@@ -1,0 +1,127 @@
+# Orchestrix Project Manifest
+
+This manifest consolidates the project vision, frontend playbook, prototype plan, roadmap, and an Agent Execution Guide to enable effective autonomous work by contributors and AI agents.
+
+## 1. Vision (summary)
+
+- Build a policy-driven API management platform (APIM-inspired) with a StencilJS-based design system for UI primitives.
+
+- Core features: modular policies (auth, cache, retry, transformation, redaction), visual policy composer, protocol bridging (OpenAPI/gRPC/MCP), AI-assisted policy tagging, and pluggable config backends (Postgres + Redis/persistent + cache).
+
+- Principles: DRY-first, feature-based boundaries, single source-of-truth design system, observability-first.
+
+## 2. Frontend Playbook (condensed)
+
+- Monorepo layout: `apps/`, `packages/ui-wc`, `packages/ui-react`, `packages/shared`, `packages/observability`, `packages/api`, etc.
+
+- Use StencilJS for primitives; generate React/Vue wrappers.
+
+- Feature structure: each feature contains `client`, `server`, `shared`, `test` folders and strict import boundaries.
+
+- Observability: centralized `packages/observability` with correlation, logging, and analytics adapters.
+
+- Testing: Vitest + MSW + Playwright; Storybook for primitives.
+
+## 3. APIM Prototype Plan (MVP)
+
+- Gateway runtime (request pipeline + policy execution).
+
+- Policies: Auth (JWT/OAuth), Cache (Redis-backed), Retry/Fallback, Request Validation.
+
+- Visual composer: React + ReactFlow for linear flows and condition branches.
+
+- Config store: Postgres (source-of-truth) + Redis (runtime cache & pub/sub).
+
+Milestones
+
+1. Policy contract and runtime composition by tag.
+
+2. Auth + Cache policies & tests.
+
+3. Composer UI with save/load.
+
+4. Redis-based cache & pub/sub.
+
+5. AI-assisted tagging (stretch).
+
+## 4. Roadmap (phases)
+
+- Phase 1 (0-3m): Prototype runtime, basic policies, composer POC.
+
+- Phase 2 (3-9m): Advanced policies, event-sourcing for config, CI, tracing.
+
+- Phase 3 (9-18m): Protocol bridging, AI features, HA & scalability.
+
+## 5. Component Library Strategy
+
+- Single source of truth: `packages/ui-wc` (Stencil primitives), wrappers in `packages/ui-react` and `packages/ui-vue`.
+
+- Build primitives first (Button, Input, Icon), then compositions (FormField, Card), then feature components.
+
+- Tokens: maintain a `packages/tokens` outputting CSS variables used by primitives.
+
+- Storybook: maintain `packages/ui-wc/.storybook` using `@storybook/web-components-vite`.
+
+## 6. Agent Execution Guide (for AI / Copilot agents)
+
+This section provides explicit rules for autonomous agents working in the repo.
+
+Agent operating principles
+
+- Follow repo playbook and manifest as the single source of truth.
+
+- Use the internal TODO manager (`manage_todo_list`) for planning; mark exactly one item `in-progress` at a time.
+
+- Make minimal, focused edits; avoid unrelated refactors.
+
+- Run build/tests when modifying code; prefer surgical edits.
+
+- Do not change secrets, KeyVault names, or production infra without explicit approval.
+
+Decision policy
+
+- Non-critical tasks: proceed autonomously (linting, tests, docs, scaffolding, storybook, small infra patches).
+
+- Critical tasks (require user confirmation): production auth changes, KeyVault/secret edits, destructive infra modifications, provisioning high-cost resources, publishing releases.
+
+Agent tooling & cadence
+
+- For Azure-related code/plans, follow Azure best-practice tool calls before code generation (as previously configured).
+
+- After every 3–5 tool actions or after editing >3 files, post a concise progress update.
+
+- Use Storybook and component builds to validate UI changes.
+
+Commit & PR policy
+
+- Make small commits with clear messages; prefer feature branches for large work.
+
+- Run `npm run --prefix src lint` and `tsc --noEmit` locally (or CI) before commits.
+
+## 7. Practical Next Actions (starter checklist)
+
+- Validate `BaseComponent` token/policy loader at runtime (minimal page using built `components` bundle).
+
+- Flesh out `packages/policy-engine` with a simple Node runtime and an `IServicePolicy` TypeScript interface.
+
+- Create a Storybook story set for primitives in `packages/ui-wc` and wire `ui-button`.
+
+- Add CI jobs to build `packages/ui-wc` and run Storybook static build.
+
+## 8. Where this file lives
+
+- Document canonical updates here (`docs/PROJECT_MANIFEST.md`). Small updates are okay via PRs.
+
+## 9. How to accept agent autonomy
+
+- Reply with one of the accept options:
+
+  - `approve-autonomy` — agent may proceed with non-critical tasks per manifest.
+
+  - `ask-to-proceed` — agent must ask before non-trivial changes.
+
+  - `manual-only` — agent must not change code without explicit human steps.
+
+---
+
+End of manifest.


### PR DESCRIPTION
Adds a consolidated project manifest and updates agent guidance to reference the manifest. Approve autonomy options are included in the manifest for reviewers.

Merge checklist (suggested):
- [ ] CI (lint & type-check) passes on PR.
- [ ] Docs spelling and formatting reviewed.
- [ ] No secrets or KeyVault names changed.
- [ ] Maintainer approves agent autonomy choice.

(If you prefer I can squash-merge once an acceptance comment is posted.)